### PR TITLE
Plugin deletion

### DIFF
--- a/system/controllers/admin/plugins_controller.php
+++ b/system/controllers/admin/plugins_controller.php
@@ -153,7 +153,8 @@ class AdminPluginsController extends AdminBase
 		$file = htmlspecialchars($file);
 		
 		$class_name = "Plugin_{$file}";
-		$class_name::__uninstall();
+		if (class_exists($class_name))
+			$class_name::__uninstall();
 		
 		$plugin = Plugin::find('file', $file);
 		$plugin->delete();


### PR DESCRIPTION
If admin deletes a plugin file and then wants to uninstall the plugin, an error is displayed cause the class doesn't exist. I say let him do it anyway.
