### PR TITLE
Suppress file_get_contents error in the admin dashboard

### DIFF
--- a/vendor/traq/controllers/admin/dashboard.php
+++ b/vendor/traq/controllers/admin/dashboard.php
@@ -64,7 +64,7 @@ class Dashboard extends AppController
      */
     private function check_for_update()
     {
-        if ($update = @file_get_contents("http://traq.io/version_check.php?version=" . urlencode(TRAQ_VER) . "&code=" . TRAQ_VER_CODE)) {
+        if ($update = file_get_contents("http://traq.io/version_check.php?version=" . urlencode(TRAQ_VER) . "&code=" . TRAQ_VER_CODE)) {
             $update = json_decode($update, true);
             View::set(compact('update'));
         }


### PR DESCRIPTION
I have here `allow_url_fopen` disabled, and as this is a considerable security issue, it's so on a number of webhosting solutions.  
What I propose is just to insert a @ character before `file_get_contents` in /vendor/traq/controllers/admin/dashboard.php. Those devs who have this disabled will have to update manually, but they won't get annoying error messages. They are especially annoying when better_php_errors is installed for debugging.
