### PR TITLE
Suppressing file_get_contents error message

### DIFF
--- a/vendor/traq/controllers/admin/dashboard.php
+++ b/vendor/traq/controllers/admin/dashboard.php
@@ -64,7 +64,7 @@ class Dashboard extends AppController
      */
     private function check_for_update()
     {
-        if ($update = file_get_contents("http://traq.io/version_check.php?version=" . urlencode(TRAQ_VER) . "&code=" . TRAQ_VER_CODE)) {
+        if ($update = @file_get_contents("http://traq.io/version_check.php?version=" . urlencode(TRAQ_VER) . "&code=" . TRAQ_VER_CODE)) {
             $update = json_decode($update, true);
             View::set(compact('update'));
         }


### PR DESCRIPTION
I think I've managed to do this at last)  
To remind you: I'm suppressing the `file_get_contents` error for those of us who have `allow_url_fopen` disabled.
